### PR TITLE
Issue#22 - generate-swagger destination-path parameter issue

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,3 +20,11 @@
   <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
 </a>
 
+# Fiza Ashraf | Contributor
+<a href="https://www.linkedin.com/in/fiza-ashraf-96319578/">
+  <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" width="200px" />
+</a>
+<a href="https://https://github.com/fizaashraf37">
+  <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
+</a>
+

--- a/flask_swagger_generator/generators/generator.py
+++ b/flask_swagger_generator/generators/generator.py
@@ -50,7 +50,7 @@ class Generator:
 
         self.specifier.set_application_name(application_name)
         self.specifier.set_application_version(application_version)
-        self.file = open(destination_path, 'w')
+        self.file = open(self.destination_path, 'w')
         self.write_specification()
         self.file.close()
         self.generated = True

--- a/tests/resources/reference_version_three.yaml
+++ b/tests/resources/reference_version_three.yaml
@@ -127,8 +127,10 @@ components:
       properties:
         id:
           type: integer
+          example: 10
         name:
           type: string
+          example: test_object
     schema_three:
       type: object
       properties:
@@ -156,12 +158,16 @@ components:
       properties:
         id:
           type: integer
+          example: 10
         name:
           type: string
+          example: test_object
     create_object_response_schema:
       type: object
       properties:
         id:
           type: integer
+          example: 10
         name:
           type: string
+          example: test_object

--- a/tests/resources/test_apis.py
+++ b/tests/resources/test_apis.py
@@ -1,0 +1,73 @@
+from tests.resources.test_app import create_app
+from flask import Blueprint, jsonify
+from flask_swagger_generator.generators import Generator
+from flask_swagger_generator.specifiers import SwaggerVersion
+from flask_swagger_generator.utils import SecurityType
+
+from marshmallow import Schema, fields
+
+class ObjectSerializer(Schema):
+    id = fields.Integer()
+    name = fields.String()
+
+
+class ObjectChildDeserializer(Schema):
+    id = fields.Integer()
+    name = fields.String()
+
+
+class ObjectDeserializer(Schema):
+    attribute_one = fields.Int()
+    attribute_two = fields.Str()
+    attribute_three = fields.Email()
+    attribute_four = fields.Boolean()
+    attribute_five = fields.URL()
+    attribute_six = fields.Nested(ObjectChildDeserializer(many=False))
+
+
+class TestAPI():
+    
+    def __init__(self):
+        self.app = create_app()
+        self.generator = Generator.of(SwaggerVersion.VERSION_THREE)
+        self.blueprint = Blueprint('objects', __name__)
+        self.create_test_api()
+        self.app.register_blueprint(self.blueprint)
+
+    def create_test_api(self):
+
+        generator = self.generator
+        blueprint = self.blueprint
+
+        schema_two = generator.create_schema(
+        'schema_two', {'id': 10, 'name': 'test_object'}
+        )
+        schema_three = generator.create_schema('schema_three', ObjectDeserializer())
+
+
+        @generator.response(200, schema_two)
+        @blueprint.route('/objects/<int:object_id>', methods=['GET'])
+        def retrieve_object(object_id, child_id):
+            return jsonify({'objects': []}), 200
+
+
+        @generator.response(204, schema_two)
+        @generator.security(SecurityType.BEARER_AUTH)
+        @blueprint.route('/objects/<int:object_id>', methods=['DELETE'])
+        def delete_object(object_id):
+            return jsonify({'objects': []}), 200
+
+
+        @generator.response(200, schema_two)
+        @generator.security(SecurityType.BEARER_AUTH)
+        @generator.request_body(schema_three)
+        @blueprint.route('/objects/<int:object_id>', methods=['PUT'])
+        def update_object(object_id):
+            pass
+
+
+        @generator.response(status_code=201, schema={'id': 10, 'name': 'test_object'})
+        @generator.request_body({'id': 10, 'name': 'test_object'})
+        @blueprint.route('/objects/<int:object_id>', methods=['POST'])
+        def create_object(object_id):
+            return jsonify({'objects': []}), 200

--- a/tests/test_generator_version_three.py
+++ b/tests/test_generator_version_three.py
@@ -3,76 +3,10 @@ from deepdiff import DeepDiff
 import pathlib
 
 from flask_testing import TestCase
-from tests.resources.test_app import create_app
-from flask import Blueprint, jsonify
-from flask_swagger_generator.generators import Generator
-from flask_swagger_generator.specifiers import SwaggerVersion
-from flask_swagger_generator.utils import SecurityType
-
-from marshmallow import Schema, fields
 
 from tests.resources.utils import yaml_as_dict
+from tests.resources.test_apis import TestAPI
 
-app = create_app()
-
-generator = Generator.of(SwaggerVersion.VERSION_THREE)
-blueprint = Blueprint('objects', __name__)
-
-
-class ObjectSerializer(Schema):
-    id = fields.Integer()
-    name = fields.String()
-
-
-class ObjectChildDeserializer(Schema):
-    id = fields.Integer()
-    name = fields.String()
-
-
-class ObjectDeserializer(Schema):
-    attribute_one = fields.Int()
-    attribute_two = fields.Str()
-    attribute_three = fields.Email()
-    attribute_four = fields.Boolean()
-    attribute_five = fields.URL()
-    attribute_six = fields.Nested(ObjectChildDeserializer(many=False))
-
-
-schema_two = generator.create_schema(
-    'schema_two', {'id': 10, 'name': 'test_object'}
-)
-schema_three = generator.create_schema('schema_three', ObjectDeserializer())
-
-
-@generator.response(200, schema_two)
-@blueprint.route('/objects/<int:object_id>', methods=['GET'])
-def retrieve_object(object_id, child_id):
-    return jsonify({'objects': []}), 200
-
-
-@generator.response(204, schema_two)
-@generator.security(SecurityType.BEARER_AUTH)
-@blueprint.route('/objects/<int:object_id>', methods=['DELETE'])
-def delete_object(object_id):
-    return jsonify({'objects': []}), 200
-
-
-@generator.response(200, schema_two)
-@generator.security(SecurityType.BEARER_AUTH)
-@generator.request_body(schema_three)
-@blueprint.route('/objects/<int:object_id>', methods=['PUT'])
-def update_object(object_id):
-    pass
-
-
-@generator.response(status_code=201, schema={'id': 10, 'name': 'test_object'})
-@generator.request_body({'id': 10, 'name': 'test_object'})
-@blueprint.route('/objects/<int:object_id>', methods=['POST'])
-def create_object(object_id):
-    return jsonify({'objects': []}), 200
-
-
-app.register_blueprint(blueprint)
 
 
 class AppTestBase(TestCase):
@@ -81,12 +15,16 @@ class AppTestBase(TestCase):
         super(AppTestBase, self).setUp()
 
     def create_app(self):
-        return app
+        self.api = TestAPI()
+        return self.api.app
 
     def tearDown(self):
         super(AppTestBase, self).tearDown()
 
-    def test(self):
+
+class TestGenerateSwagger(AppTestBase):
+    
+    def test_with_dest_path(self):
 
         generated_path = os.path.join(
             pathlib.Path(__file__).parent.absolute()
@@ -96,10 +34,34 @@ class AppTestBase(TestCase):
             pathlib.Path(__file__).parent.absolute()
         ) + '/resources/reference_version_three.yaml'
 
+        generator = self.api.generator
+
         generator.generate_swagger(
             self.app, generated_path
         )
 
+        self.verify_output(generated_path, reference_path)
+
+
+    def test_without_dest_path(self):
+
+        generated_path = os.path.join(
+            pathlib.Path(__file__).parent.parent.absolute()
+        ) + '/swagger.yaml'
+
+        reference_path = os.path.join(
+            pathlib.Path(__file__).parent.absolute()
+        ) + '/resources/reference_version_three.yaml'
+
+        generator = self.api.generator
+
+        generator.generate_swagger(
+            self.app, generated_path
+        )
+
+        self.verify_output(generated_path, reference_path)
+
+    def verify_output(self, generated_path, reference_path):
         generated_yaml = yaml_as_dict(generated_path)
         reference_yaml = yaml_as_dict(reference_path)
 
@@ -108,3 +70,4 @@ class AppTestBase(TestCase):
 
         difference = DeepDiff(generated_yaml, reference_yaml, ignore_order=True)
         self.assertEqual({}, difference)
+        os.remove(generated_path)


### PR DESCRIPTION
The issue was due to the below line of code in Generator class line 53

`self.file = open(destination_path, 'w')`

If user does not provides the destination path parameter then it is None and line 46 and 47 set self.destination_path to current directory path if it is None. This line should be as below to fix this. 

`self.file = open(self.destination_path, 'w')`
