### PR TITLE
Issue#24 - New Feature - Option to add Server URL

### DIFF
--- a/flask_swagger_generator/generators/generator.py
+++ b/flask_swagger_generator/generators/generator.py
@@ -39,7 +39,8 @@ class Generator:
             app: Flask,
             destination_path: str = None,
             application_name: str = 'Application',
-            application_version: str = '1.0.0'
+            application_version: str = '1.0.0',
+            server_url: str = "/"
     ):
         self.index_endpoints(app)
 
@@ -50,6 +51,7 @@ class Generator:
 
         self.specifier.set_application_name(application_name)
         self.specifier.set_application_version(application_version)
+        self.specifier.set_server_url(server_url)
         self.file = open(destination_path, 'w')
         self.write_specification()
         self.file.close()

--- a/flask_swagger_generator/specifiers/swagger_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_specifier.py
@@ -8,6 +8,7 @@ class SwaggerSpecifier(ABC):
     def __init__(self):
         self.application_name = None
         self.application_version = None
+        self.server_url = None
 
     @abstractmethod
     def add_response(
@@ -46,6 +47,9 @@ class SwaggerSpecifier(ABC):
 
     def set_application_version(self, application_version):
         self.application_version = application_version
+
+    def set_server_url(self, server_url):
+        self.server_url = server_url
 
     @abstractmethod
     def clean(self):

--- a/flask_swagger_generator/specifiers/swagger_three_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_three_specifier.py
@@ -480,11 +480,12 @@ class SwaggerThreeSpecifier(SwaggerModel, SwaggerSpecifier):
               description: Find out more about Swagger
               url: 'http://swagger.io'
             servers:
-              - url: /
+              - url: {server_url}
             """.format(
                 name=self.application_name,
                 version=self.application_version,
-                time=datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+                time=datetime.now().strftime("%d/%m/%Y %H:%M:%S"),
+                server_url=self.server_url
             )
         )
 

--- a/tests/resources/test_apis.py
+++ b/tests/resources/test_apis.py
@@ -25,7 +25,7 @@ class ObjectDeserializer(Schema):
     attribute_six = fields.Nested(ObjectChildDeserializer(many=False))
 
 
-class TestAPI():
+class TestVersionThreeAPI():
     
     def __init__(self):
         self.app = create_app()

--- a/tests/test_generator_version_three.py
+++ b/tests/test_generator_version_three.py
@@ -5,7 +5,7 @@ import pathlib
 from flask_testing import TestCase
 
 from tests.resources.utils import yaml_as_dict
-from tests.resources.test_apis import TestAPI
+from tests.resources.test_apis import TestVersionThreeAPI
 
 
 
@@ -15,59 +15,73 @@ class AppTestBase(TestCase):
         super(AppTestBase, self).setUp()
 
     def create_app(self):
-        self.api = TestAPI()
-        return self.api.app
+        self.api = TestVersionThreeAPI()
+        self.generator = self.api.generator
+        return self.api.app  
 
     def tearDown(self):
         super(AppTestBase, self).tearDown()
 
 
-class TestGenerateSwagger(AppTestBase):
+class TestGenerateSwaggerV3(AppTestBase):
+
+    def setUp(self) -> None:
+        self.generated_path = os.path.join(
+            pathlib.Path(__file__).parent.absolute()
+        ) + '/resources/generated.yaml'
+        
+        self.reference_path = os.path.join(
+                pathlib.Path(__file__).parent.absolute()
+            ) + '/resources/reference_version_three.yaml'
+
+    def tearDown(self):
+        os.remove(self.generated_path)
     
     def test_with_dest_path(self):
 
-        generated_path = os.path.join(
-            pathlib.Path(__file__).parent.absolute()
-        ) + '/resources/generated.yaml'
-
-        reference_path = os.path.join(
-            pathlib.Path(__file__).parent.absolute()
-        ) + '/resources/reference_version_three.yaml'
-
-        generator = self.api.generator
-
-        generator.generate_swagger(
-            self.app, generated_path
+        self.generator.generate_swagger(
+            self.app, self.generated_path
         )
 
-        self.verify_output(generated_path, reference_path)
-
+        self.verify_output(self.generated_path, self.reference_path)
 
     def test_without_dest_path(self):
 
-        generated_path = os.path.join(
+        self.generated_path = os.path.join(
             pathlib.Path(__file__).parent.parent.absolute()
         ) + '/swagger.yaml'
 
-        reference_path = os.path.join(
-            pathlib.Path(__file__).parent.absolute()
-        ) + '/resources/reference_version_three.yaml'
+        self.generator.generate_swagger(self.app)
 
-        generator = self.api.generator
+        self.verify_output(self.generated_path, self.reference_path)
 
-        generator.generate_swagger(
-            self.app, generated_path
+    def test_server_url(self):
+        server_url = "http://localhost:8000"
+
+        self.generator.generate_swagger(
+            self.app, self.generated_path, server_url=server_url
         )
 
-        self.verify_output(generated_path, reference_path)
+        generated_yaml, reference_yaml = \
+            self.yaml_as_dict(self.generated_path, self.reference_path)
 
-    def verify_output(self, generated_path, reference_path):
+        reference_yaml['servers'][0]['url'] = server_url
+
+        difference = DeepDiff(generated_yaml, reference_yaml, ignore_order=True)
+        self.assertEqual({}, difference)
+        
+
+    def yaml_as_dict(self, generated_path, reference_path):
         generated_yaml = yaml_as_dict(generated_path)
         reference_yaml = yaml_as_dict(reference_path)
 
         reference_yaml['info'].pop('description')
         generated_yaml['info'].pop('description')
 
+        return generated_yaml, reference_yaml
+
+    def verify_output(self, generated_path, reference_path):
+        generated_yaml, reference_yaml = \
+             self.yaml_as_dict(generated_path, reference_path)
         difference = DeepDiff(generated_yaml, reference_yaml, ignore_order=True)
         self.assertEqual({}, difference)
-        os.remove(generated_path)


### PR DESCRIPTION
[Issue#24](https://github.com/coding-kitties/flask-swagger-generator/issues/24)

User can now add custom Sever URL:

**Example:**

```
SERVER_URL = "http://localhost:8080"
generator.generate_swagger(app, 
                destination_path="/static/swagger.yaml", 
                server_url="http://localhost:8080"
)
```
