### PR TITLE
Issue#26 : New Feature - Option to add custom tag to group Endpoints

### DIFF
--- a/flask_swagger_generator/generators/generator.py
+++ b/flask_swagger_generator/generators/generator.py
@@ -105,6 +105,21 @@ class Generator:
             return wrapper
         return swagger_security
 
+    def path_tag(self, tag):
+        def swagger_path_tag(func):
+
+            if not self.generated:
+                self.specifier.add_path_tag(
+                    func.__name__, tag
+                )
+
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+        return swagger_path_tag
+
     def create_schema(self, reference_name, properties):
         return self.specifier.create_schema(reference_name, properties)
 
@@ -116,17 +131,16 @@ class Generator:
 
         for rule in app.url_map.iter_rules():
 
+            group = None
+            function_name = rule.endpoint
             if len(rule.endpoint.split(".")) > 1:
                 group, function_name = rule.endpoint.split('.')
-                self.specifier.add_endpoint(
+            for path_tag in self.specifier.path_tags:
+                if path_tag.get("function_name") == function_name:
+                    group = path_tag.get("tag")
+            self.specifier.add_endpoint(
                     function_name=function_name,
                     path=str(rule),
                     request_types=rule.methods,
                     group=group
-                )
-            else:
-                self.specifier.add_endpoint(
-                    function_name=rule.endpoint,
-                    path=str(rule),
-                    request_types=rule.methods,
                 )

--- a/flask_swagger_generator/specifiers/swagger_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_specifier.py
@@ -41,6 +41,10 @@ class SwaggerSpecifier(ABC):
     def add_security(self, function_name, security_type: SecurityType):
         raise NotImplementedError()
 
+    @abstractmethod
+    def add_path_tag(self, function_name, tag):
+        raise NotImplementedError()
+
     def set_application_name(self, application_name):
         self.application_name = application_name
 

--- a/flask_swagger_generator/specifiers/swagger_three_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_three_specifier.py
@@ -462,6 +462,7 @@ class SwaggerThreeSpecifier(SwaggerModel, SwaggerSpecifier):
         self.schemas = []
         self.responses = []
         self.securities = []
+        self.path_tags = []
 
     def perform_write(self, file):
         # Add all request bodies to request_types with same function name
@@ -674,6 +675,10 @@ class SwaggerThreeSpecifier(SwaggerModel, SwaggerSpecifier):
 
         security_model = SwaggerSecurity([function_name], security_type)
         self.securities.append(security_model)
+
+    def add_path_tag(self, function_name: str, tag):
+        path_tag = {"function_name": function_name, "tag": tag}
+        self.path_tags.append(path_tag)
 
     def create_schema(self, reference_name, properties):
         schema = SwaggerSchema(reference_name, properties)


### PR DESCRIPTION
[Issue#26](https://github.com/coding-kitties/flask-swagger-generator/issues/26)

User can now specify custom tag for endpoint as in this example:

@generator.path_tag("Test")
@app.route('/objects/<int:object_id>', methods=['PUT'])
def update_object(object_id):
    return jsonify({'id': 1, 'name': 'test_object_name'}), 201