### PR TITLE
Issue#28 : New Feature - Support for nested schema for json request/r…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,17 +1,13 @@
 # Marc van Duyn | Mod and Contributor
-<a href="https://linkedin.com/in/marc-van-duyn">
-  <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" width="200px" />
-</a>
-<br/>
-<a href="https://github.com/MDUYN">
-  <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
-</a>
+
+<a href="https://linkedin.com/in/marc-van-duyn"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" width="200px" /></a> <a href="https://github.com/MDUYN">
+      <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
+    </a>
 
 # Jibbe Verhave | Mod and Contributor
 <a href="https://www.linkedin.com/in/jibbe-verhave-b7465749/">
   <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" width="200px" />
 </a>
-<br/>
 <a href="https://github.com/Chirema">
   <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
 </a>
@@ -20,7 +16,6 @@
 <a href="https://www.linkedin.com/in/oracking-amenreynolds/">
   <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" width="200px" />
 </a>
-<br/>
 <a href="https://github.com/Oracking">
   <img src="https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white" width="200px" />
 </a>

--- a/flask_swagger_generator/specifiers/swagger_three_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_three_specifier.py
@@ -68,7 +68,7 @@ class SwaggerSchema(SwaggerModel):
             for key in schema:
                 self.properties[key] = "type: {}".format(
                     self.get_type(schema[key]).value
-                )
+                ) + "\n\t\t      example: {}".format(schema[key])
 
         elif isinstance(schema, MarshmallowSchema):
 
@@ -118,6 +118,8 @@ class SwaggerSchema(SwaggerModel):
             return InputType.NUMBER
         elif isinstance(value, list):
             return InputType.ARRAY
+        elif isinstance(value, dict):
+            return InputType.OBJECT
         else:
             SwaggerGeneratorException(
                 "Type {} is not supported".format(type(value))


### PR DESCRIPTION
[Issue#28](https://github.com/coding-kitties/flask-swagger-generator/issues/28)

User can now specify nested json schemas in request and response. The nested objects e.g. list or dict will be added as example to keep things simple. As parsing each nested object will make schema very complex with increased nesting levels.
With this simple approach user can add any level of nesting to json and yaml generated will be simple.

**Example**

```
request_schema = {
    "id": 10, 
    "name": "level01", 
    "nested_dict": {
        "id":1, 
        "name":"level02",
        "values" : {
            "id": 3,
            "name": "level03"
        }
    }, 
    "nested_list": [
        {"a":1},
        {"b":2}
    ]
}

@generator.request_body(request_schema)
@blueprint.route('/objects/<int:object_id>', methods=['PUT'])
def update_object(object_id):
    return jsonify({'id': 1, 'name': 'test_object_name'}), 201
```