### PR TITLE
Issue#7 : Added Support for "path" InputType

### DIFF
--- a/flask_swagger_generator/utils/input_type.py
+++ b/flask_swagger_generator/utils/input_type.py
@@ -37,6 +37,8 @@ class InputType(Enum):
                 return InputType.NESTED
             elif value.lower() == 'datetime':
                 return InputType.STRING
+            elif value.lower() == 'path':
+                return InputType.STRING
             else:
                 raise SwaggerGeneratorException(
                     'Could not convert value {} to a input type'.format(


### PR DESCRIPTION
[Issue#7](https://github.com/coding-kitties/flask-swagger-generator/issues/7)

User can now add an endpoint for with path input type:

**Example:**
```
@blueprint.route('/objects/<path:name>')
def get_object(name):
    return jsonify({'id': 1, 'name': 'test_object_name'}), 201
```