### PR TITLE
Issue#21 : New Feature - Added support for query parameters

### DIFF
--- a/flask_swagger_generator/generators/generator.py
+++ b/flask_swagger_generator/generators/generator.py
@@ -105,6 +105,32 @@ class Generator:
             return wrapper
         return swagger_security
 
+    def query_parameters(self, parameters):
+        """Example: 
+        @generator.query_parameters(parameters = [
+                        {
+                            "name":"string",
+                            "type":"string",
+                            "description":"string",
+                            "required": false,
+                            "allowReserved": false
+                        }
+                    ])
+        """
+        def swagger_query_parameters(func):
+
+            if not self.generated:
+                self.specifier.add_query_parameters(
+                    func.__name__, parameters
+                )
+
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+        return swagger_query_parameters
+
     def create_schema(self, reference_name, properties):
         return self.specifier.create_schema(reference_name, properties)
 

--- a/flask_swagger_generator/specifiers/swagger_specifier.py
+++ b/flask_swagger_generator/specifiers/swagger_specifier.py
@@ -30,7 +30,7 @@ class SwaggerSpecifier(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def add_query_parameters(self):
+    def add_query_parameters(self, function_name, parameters):
         raise NotImplementedError()
 
     @abstractmethod


### PR DESCRIPTION
[Issue#21](https://github.com/coding-kitties/flask-swagger-generator/issues/21)

User can now add query parameters along with path parameters.

**Example:**
```
query_parameters =  [
        {
            "name":"param1",
            "type":"string",
        },
        {
            "name":"param2",
            "type":"int",
        }
    ]

@generator.query_parameters(query_parameters)
@blueprint.route('/objects/<int:id>/<string:name>')
def get_object(name):
    return jsonify({'id': 1, 'name': 'test_object_name'}), 201
```

This will add 2 path parameters _id_ and _name_ to the path and two query parameters  _param1_ and _param2_